### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,150 +4,150 @@
 
 ### Patch Changes
 
-- [#44](https://github.com/gsoft-inc/wl-chromado/pull/44) [`a142283`](https://github.com/gsoft-inc/wl-chromado/commit/a1422835e54732c79d4b7e1859a9fb7d1689027b) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Default branch baseline was not updated properly when a custom default branch was provided.
+- [#44](https://github.com/workleap/wl-chromado/pull/44) [`a142283`](https://github.com/workleap/wl-chromado/commit/a1422835e54732c79d4b7e1859a9fb7d1689027b) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Default branch baseline was not updated properly when a custom default branch was provided.
 
 ## 1.2.0
 
 ### Minor Changes
 
-- [#42](https://github.com/gsoft-inc/wl-chromado/pull/42) [`d2b21a2`](https://github.com/gsoft-inc/wl-chromado/commit/d2b21a217f722591271dfca78ca3aa124ab5f427) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a new CHROMATIC_DEFAULT_BRANCH option to configure the name of the repository default branch.
+- [#42](https://github.com/workleap/wl-chromado/pull/42) [`d2b21a2`](https://github.com/workleap/wl-chromado/commit/d2b21a217f722591271dfca78ca3aa124ab5f427) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a new CHROMATIC_DEFAULT_BRANCH option to configure the name of the repository default branch.
 
 ## 1.1.1
 
 ### Patch Changes
 
-- [#37](https://github.com/gsoft-inc/wl-chromado/pull/37) [`81afdbf`](https://github.com/gsoft-inc/wl-chromado/commit/81afdbfaafb35fa651c0f99e7589878ab3aa46e3) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fix a typo in the new snapshot line.
+- [#37](https://github.com/workleap/wl-chromado/pull/37) [`81afdbf`](https://github.com/workleap/wl-chromado/commit/81afdbfaafb35fa651c0f99e7589878ab3aa46e3) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fix a typo in the new snapshot line.
 
 ## 1.1.0
 
 ### Minor Changes
 
-- [#34](https://github.com/gsoft-inc/wl-chromado/pull/34) [`3c6840a`](https://github.com/gsoft-inc/wl-chromado/commit/3c6840a5f8ed3b9337693cff4f9bfaac550d547e) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a new row to the PR message identifying the number of snapshots taken for the build.
+- [#34](https://github.com/workleap/wl-chromado/pull/34) [`3c6840a`](https://github.com/workleap/wl-chromado/commit/3c6840a5f8ed3b9337693cff4f9bfaac550d547e) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a new row to the PR message identifying the number of snapshots taken for the build.
 
 ## 1.0.2
 
 ### Patch Changes
 
-- [#29](https://github.com/gsoft-inc/wl-chromado/pull/29) [`9964503`](https://github.com/gsoft-inc/wl-chromado/commit/9964503c1d7bcf72de5f2fd1e3a53862e8e436b4) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added snapshots count to the PR message.
+- [#29](https://github.com/workleap/wl-chromado/pull/29) [`9964503`](https://github.com/workleap/wl-chromado/commit/9964503c1d7bcf72de5f2fd1e3a53862e8e436b4) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added snapshots count to the PR message.
 
 ## 1.0.1
 
 ### Patch Changes
 
-- [`1752b4a`](https://github.com/gsoft-inc/wl-chromado/commit/1752b4aab74843ce3054edbc4456697fd6cbbde7) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing a few typos after the rebranding to Chromado.
+- [`1752b4a`](https://github.com/workleap/wl-chromado/commit/1752b4aab74843ce3054edbc4456697fd6cbbde7) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing a few typos after the rebranding to Chromado.
 
 ## 1.0.0
 
 ### Major Changes
 
-- [`7fda8c8`](https://github.com/gsoft-inc/wl-chromado/commit/7fda8c8863b254ee7b48110dbf506515ec1cb01f) Thanks [@patricklafrance](https://github.com/patricklafrance)! - First stable release and renamed to @workleap/chromado.
+- [`7fda8c8`](https://github.com/workleap/wl-chromado/commit/7fda8c8863b254ee7b48110dbf506515ec1cb01f) Thanks [@patricklafrance](https://github.com/patricklafrance)! - First stable release and renamed to @workleap/chromado.
 
 ## 0.0.18
 
 ### Patch Changes
 
-- [`9d20d61`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/9d20d613bbc3ecaf68bada4425e0c030d7329ab7) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Changed how Chromatic errors are handled.
+- [`9d20d61`](https://github.com/workleap/wl-chromatic-ado/commit/9d20d613bbc3ecaf68bada4425e0c030d7329ab7) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Changed how Chromatic errors are handled.
 
 ## 0.0.17
 
 ### Patch Changes
 
-- [`f726272`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/f726272d872e87a24b32e1112cc78501ffc75a31) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Visual changes to the PR comment message.
+- [`f726272`](https://github.com/workleap/wl-chromatic-ado/commit/f726272d872e87a24b32e1112cc78501ffc75a31) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Visual changes to the PR comment message.
 
 ## 0.0.16
 
 ### Patch Changes
 
-- [`8392589`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/8392589ffdcdfac4b8840f344f007615dce71af6) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Improved logging.
+- [`8392589`](https://github.com/workleap/wl-chromatic-ado/commit/8392589ffdcdfac4b8840f344f007615dce71af6) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Improved logging.
 
-- [`2809fa1`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/2809fa11bc388e9e36f2eb9a0073c190331a6885) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Updated the PR comment UI
+- [`2809fa1`](https://github.com/workleap/wl-chromatic-ado/commit/2809fa11bc388e9e36f2eb9a0073c190331a6885) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Updated the PR comment UI
 
 ## 0.0.15
 
 ### Patch Changes
 
-- [`90431e7`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/90431e715fe10851c15e5fe8254725459d3cb563) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing verbose mode.
+- [`90431e7`](https://github.com/workleap/wl-chromatic-ado/commit/90431e715fe10851c15e5fe8254725459d3cb563) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing verbose mode.
 
 ## 0.0.14
 
 ### Patch Changes
 
-- [`1291e28`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/1291e2838997a9b60aa012a09e978c07cd97714d) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Forgot to build the code for the previous release.
+- [`1291e28`](https://github.com/workleap/wl-chromatic-ado/commit/1291e2838997a9b60aa012a09e978c07cd97714d) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Forgot to build the code for the previous release.
 
 ## 0.0.13
 
 ### Patch Changes
 
-- [`963fd8c`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/963fd8c903306317266b063895b346ba15476eb8) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a verbose mode.
+- [`963fd8c`](https://github.com/workleap/wl-chromatic-ado/commit/963fd8c903306317266b063895b346ba15476eb8) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added a verbose mode.
 
 ## 0.0.12
 
 ### Patch Changes
 
-- [`999565b`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/999565b5e21a1b1fe2e5e8e07c2a6d64a652957a) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Final enhancements before the first major release.
+- [`999565b`](https://github.com/workleap/wl-chromatic-ado/commit/999565b5e21a1b1fe2e5e8e07c2a6d64a652957a) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Final enhancements before the first major release.
 
 ## 0.0.11
 
 ### Patch Changes
 
-- [`24798e0`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/24798e0a19dbf31ef8f8ce6288e2dcc522dea056) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Minor changes.
+- [`24798e0`](https://github.com/workleap/wl-chromatic-ado/commit/24798e0a19dbf31ef8f8ce6288e2dcc522dea056) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Minor changes.
 
 ## 0.0.10
 
 ### Patch Changes
 
-- [`bfd6271`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/bfd6271c2e83f33d41f08d000d097cb52c7e19f9) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added improvements.
+- [`bfd6271`](https://github.com/workleap/wl-chromatic-ado/commit/bfd6271c2e83f33d41f08d000d097cb52c7e19f9) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Added improvements.
 
 ## 0.0.9
 
 ### Patch Changes
 
-- [`9b1f69b`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/9b1f69beb858d8f02fd222e13f0da7719c70c814) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing a bug.
+- [`9b1f69b`](https://github.com/workleap/wl-chromatic-ado/commit/9b1f69beb858d8f02fd222e13f0da7719c70c814) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing a bug.
 
 ## 0.0.8
 
 ### Patch Changes
 
-- [`e17c7bc`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/e17c7bcd8c5a5681881d8414975851a039a22259) Thanks [@patricklafrance](https://github.com/patricklafrance)! - New improvements
+- [`e17c7bc`](https://github.com/workleap/wl-chromatic-ado/commit/e17c7bcd8c5a5681881d8414975851a039a22259) Thanks [@patricklafrance](https://github.com/patricklafrance)! - New improvements
 
 ## 0.0.7
 
 ### Patch Changes
 
-- [`130e97c`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/130e97cc6a42902a4747c2f8114eea03121198ac) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Debugging
+- [`130e97c`](https://github.com/workleap/wl-chromatic-ado/commit/130e97cc6a42902a4747c2f8114eea03121198ac) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Debugging
 
 ## 0.0.6
 
 ### Patch Changes
 
-- [`7134b59`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/7134b59ae38d7d0217eb34cc126a7f19b7b27c60) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing argv logging.
+- [`7134b59`](https://github.com/workleap/wl-chromatic-ado/commit/7134b59ae38d7d0217eb34cc126a7f19b7b27c60) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Fixing argv logging.
 
 ## 0.0.5
 
 ### Patch Changes
 
-- [`7e74634`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/7e746349f719416838589d0ae05ab294206af56a) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Trying to deprecated the azure devops script.
+- [`7e74634`](https://github.com/workleap/wl-chromatic-ado/commit/7e746349f719416838589d0ae05ab294206af56a) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Trying to deprecated the azure devops script.
 
 ## 0.0.4
 
 ### Patch Changes
 
-- [`38924b4`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/38924b4586af91cf254fbe29f1143cc50c29f0b2) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Adding a short version of the ado script
+- [`38924b4`](https://github.com/workleap/wl-chromatic-ado/commit/38924b4586af91cf254fbe29f1143cc50c29f0b2) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Adding a short version of the ado script
 
 ## 0.0.3
 
 ### Patch Changes
 
-- [#6](https://github.com/gsoft-inc/wl-chromatic-ado/pull/6) [`728386c`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/728386c13e85ccdf555483153db3b2b12b0478ea) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Publishing without a scope
+- [#6](https://github.com/workleap/wl-chromatic-ado/pull/6) [`728386c`](https://github.com/workleap/wl-chromatic-ado/commit/728386c13e85ccdf555483153db3b2b12b0478ea) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Publishing without a scope
 
 ## 0.0.2
 
 ### Patch Changes
 
-- [#4](https://github.com/gsoft-inc/wl-chromatic-ado/pull/4) [`291a943`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/291a943175369787c8b9e7a2ccee598163614b4c) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Publishing a beta version.
+- [#4](https://github.com/workleap/wl-chromatic-ado/pull/4) [`291a943`](https://github.com/workleap/wl-chromatic-ado/commit/291a943175369787c8b9e7a2ccee598163614b4c) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Publishing a beta version.
 
 ## 0.0.1
 
 ### Patch Changes
 
-- [#1](https://github.com/gsoft-inc/wl-chromatic-ado/pull/1) [`9d14c43`](https://github.com/gsoft-inc/wl-chromatic-ado/commit/9d14c43390c940f5396e728d6990a4ad221da1aa) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Initial beta version.
+- [#1](https://github.com/workleap/wl-chromatic-ado/pull/1) [`9d14c43`](https://github.com/workleap/wl-chromatic-ado/commit/9d14c43390c940f5396e728d6990a4ad221da1aa) Thanks [@patricklafrance](https://github.com/patricklafrance)! - Initial beta version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ pnpm update-outdated-deps
 
 We use [GitHub Actions](https://github.com/features/actions) for this repository.
 
-You can find the configuration in the [.github/workflows](.github/workflows/) folder and the build results are available [here](https://github.com/gsoft-inc/wl-squide/actions).
+You can find the configuration in the [.github/workflows](.github/workflows/) folder and the build results are available [here](https://github.com/workleap/wl-squide/actions).
 
 We currently have 3 builds configured:
 
@@ -146,6 +146,6 @@ This action will trigger when a commit is done in a PR to `main` or after a push
 
 ### Retype
 
-This action will trigger when a commit is done in a PR to `main` or after a push to `main`. The action will generate the documentation website into the `retype` branch. This repository [Github Pages](https://github.com/gsoft-inc/wl-web-configs/settings/pages) is configured to automatically deploy the website from the `retype` branch.
+This action will trigger when a commit is done in a PR to `main` or after a push to `main`. The action will generate the documentation website into the `retype` branch. This repository [Github Pages](https://github.com/workleap/wl-web-configs/settings/pages) is configured to automatically deploy the website from the `retype` branch.
 
 If you are having issue with the Retype license, make sure the `RETYPE_API_KEY` Github secret contains a valid Retype license.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To ask a question or propose an idea, feel free to start a new [discussion](http
 
 ## Documentation
 
-View the [user's documentation](https://gsoft-inc.github.io/wl-chromado).
+View the [user's documentation](https://workleap.github.io/wl-chromado).
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 A library to easily integrate [Chromatic](https://www.chromatic.com/) with [Azure Pipelines](https://azure.microsoft.com/en-ca/products/devops/pipelines).
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
-[![CI](https://github.com/gsoft-inc/wl-chromado/actions/workflows/ci.yml/badge.svg)](https://github.com/gsoft-inc/wl-chromado/actions/workflows/ci.yml)
+[![CI](https://github.com/workleap/wl-chromado/actions/workflows/ci.yml/badge.svg)](https://github.com/workleap/wl-chromado/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@workleap/chromado)](https://www.npmjs.com/package/@workleap/chromado)
 
 ## Have a question or found an issue?
 
-To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/gsoft-inc/wl-chromado/discussions). If you found a bug, please open an [issue](https://github.com/gsoft-inc/wl-chromado/issues).
+To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/workleap/wl-chromado/discussions). If you found a bug, please open an [issue](https://github.com/workleap/wl-chromado/issues).
 
 ## Documentation
 
@@ -20,4 +20,4 @@ View the [contributor's documentation](./CONTRIBUTING.md).
 
 ## License
 
-Copyright © 2024, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/workleap-license/blob/master/LICENSE.
+Copyright © 2024, Workleap This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/workleap-license/blob/master/LICENSE.

--- a/docs/about.md
+++ b/docs/about.md
@@ -4,12 +4,12 @@ layout: page
 
 # About
 
-To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/gsoft-inc/wl-chromado/discussions) on Github. If you found a bug, please open an [issue](https://github.com/gsoft-inc/wl-chromado/issues) on Github.
+To ask a question or propose an idea, feel free to start a new [discussion](https://github.com/workleap/wl-chromado/discussions) on Github. If you found a bug, please open an [issue](https://github.com/workleap/wl-chromado/issues) on Github.
 
 ## Contributing
 
-Have a look at the [contributor's documentation](https://github.com/gsoft-inc/wl-chromado/blob/main/CONTRIBUTING.md).
+Have a look at the [contributor's documentation](https://github.com/workleap/wl-chromado/blob/main/CONTRIBUTING.md).
 
 ## License
 
-See the [LICENSE](https://github.com/gsoft-inc/wl-chromado/blob/main/LICENSE) on Github.
+See the [LICENSE](https://github.com/workleap/wl-chromado/blob/main/LICENSE) on Github.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/gsoft-inc/wl-chromado.git"
+        "url": "git+https://github.com/workleap/wl-chromado.git"
     },
     "publishConfig": {
         "access": "public",

--- a/retype.yml
+++ b/retype.yml
@@ -38,7 +38,7 @@ branding:
 favicon: ./static/favicon.png
 
 edit:
-    repo: "https://github.com/gsoft-inc/wl-chromado"
+    repo: "https://github.com/workleap/wl-chromado"
     base: /docs
     branch: main
 
@@ -49,22 +49,22 @@ links:
 
     - text: Found a bug?
       icon: issue-opened
-      link: https://github.com/gsoft-inc/wl-chromado/issues
+      link: https://github.com/workleap/wl-chromado/issues
       target: blank
 
     - text: Feature requests
       icon: comment-discussion
-      link: https://github.com/gsoft-inc/wl-chromado/discussions
+      link: https://github.com/workleap/wl-chromado/discussions
       target: blank
 
     - text: Releases
       icon: tag
-      link: https://github.com/gsoft-inc/wl-chromado/releases
+      link: https://github.com/workleap/wl-chromado/releases
       target: blank
 
     - text: Github
       icon: mark-github
-      link: https://github.com/gsoft-inc/wl-chromado
+      link: https://github.com/workleap/wl-chromado
       target: blank
 
     - text: NPM
@@ -81,7 +81,7 @@ footer:
 
         - text: License
           icon: shield-check
-          link: https://github.com/gsoft-inc/wl-chromado/blob/main/LICENSE
+          link: https://github.com/workleap/wl-chromado/blob/main/LICENSE
           target: blank
 
 # To allow using {{ }} in code blocks.

--- a/retype.yml
+++ b/retype.yml
@@ -16,7 +16,7 @@ toc:
     depth: 2
 
 hub:
-    link: https://gsoft-inc.github.io/wl-idp-docs-hub/
+    link: https://workleap.github.io/wl-idp-docs-hub/
     alt: Workleap's IDP homepage
 
 start:
@@ -29,7 +29,7 @@ start:
 input: ./docs
 output: .retype
 
-url: https://gsoft-inc.github.io/wl-chromado/
+url: https://workleap.github.io/wl-chromado/
 
 branding:
     title: "Chromado"

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -139,7 +139,7 @@ ${changeCount === 0
         <td>
 ${output.inheritedCaptureCount !== 0
         ? `✅&nbsp; Captured ${output.actualCaptureCount} snapshots and inherited from ${output.inheritedCaptureCount} TurboSnaps`
-        : "❌&nbsp; This build is not using <a href=\"https://www.chromatic.com/docs/turbosnap\" target=\"blank\" aria-label=\"https://www.chromatic.com/docs/turbosnap (Opens in a new window or tab)\">TurboSnap</a>. Be sure to read Workleap's <a href=\"https://gsoft-inc.github.io/wl-chromado/best-practices\" target=\"blank\" aria-label=\"https://gsoft-inc.github.io/wl-chromado/best-practices (Opens in a new window or tab)\">best practices<a/> for Chromatic."
+        : "❌&nbsp; This build is not using <a href=\"https://www.chromatic.com/docs/turbosnap\" target=\"blank\" aria-label=\"https://www.chromatic.com/docs/turbosnap (Opens in a new window or tab)\">TurboSnap</a>. Be sure to read Workleap's <a href=\"https://workleap.github.io/wl-chromado/best-practices\" target=\"blank\" aria-label=\"https://workleap.github.io/wl-chromado/best-practices (Opens in a new window or tab)\">best practices<a/> for Chromatic."
 }
         </td>
         </tr>


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 