### PR TITLE
fix: No longer fail on rerun after changes have been accepted

### DIFF
--- a/.changeset/gold-cougars-fly.md
+++ b/.changeset/gold-cougars-fly.md
@@ -2,4 +2,4 @@
 "@workleap/chromado": patch
 ---
 
-Fix failling task after changes have been accepted on rerun
+Fix failing task after changes have been accepted on rerun

--- a/.changeset/gold-cougars-fly.md
+++ b/.changeset/gold-cougars-fly.md
@@ -1,0 +1,5 @@
+---
+"@workleap/chromado": patch
+---
+
+Fix failling task after changes have been accepted on rerun

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     },
     "dependencies": {
         "azure-pipelines-task-lib": "^4.17.3",
-        "chromatic": "^11.27.0"
+        "chromatic": "^11.28.1"
     },
     "devDependencies": {
         "@changesets/changelog-github": "0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^4.17.3
         version: 4.17.3
       chromatic:
-        specifier: ^11.27.0
-        version: 11.27.0
+        specifier: ^11.28.1
+        version: 11.28.2
     devDependencies:
       '@changesets/changelog-github':
         specifier: 0.5.1
@@ -890,8 +890,8 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chromatic@11.27.0:
-    resolution: {integrity: sha512-jQ2ufjS+ePpg+NtcPI9B2eOi+pAzlRd2nhd1LgNMsVCC9Bzf5t8mJtyd8v2AUuJS0LdX0QVBgkOnlNv9xviHzA==}
+  chromatic@11.28.2:
+    resolution: {integrity: sha512-aCmUPcZUs4/p9zRZdMreOoO/5JqO2DiJC3md1/vRx8dlMRcmR/YI5ZbgXZcai2absVR+6hsXZ5XiPxV2sboTuQ==}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -3818,7 +3818,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chromatic@11.27.0: {}
+  chromatic@11.28.2: {}
 
   ci-info@3.9.0: {}
 


### PR DESCRIPTION
The euristic we used to identity accepted re-builds no longer works as version [v11.28.1](https://github.com/chromaui/chromatic-cli/releases/tag/v11.28.1) of Chromatic.

Since re-builds now always include Chromatic and Storybook URLs, we can remove the `output.url === undefined && output.storybookUrl === undefined` check and use the `output.code` as the single source of truth as to whether a build is successful or not.

We can now actually updates comment on successful re-builds, which we couldn't do before because we didn't have the URLs.